### PR TITLE
Parsing Measures & Scenarios + Analysis Results Display & Recalculation

### DIFF
--- a/beam_opt/models/optimizer.py
+++ b/beam_opt/models/optimizer.py
@@ -104,7 +104,7 @@ class Optimizer:
         # Set target attribute
         target_df = pd.DataFrame({'Target': target, 'Year': self.timeline})
         target_df = target_df.merge(self.timeline_df, on='Year', how='right').fillna(method='ffill').set_index('Year')
-        setattr(self, lookup['target'], target_df.Target * 1000)
+        setattr(self, lookup['target'], target_df.Target * 1000) # target_df.Target is in mtCO2e, convert to kg
 
         return {'status': 'success', 'message': ''}
 

--- a/beam_opt/models/optimizer.py
+++ b/beam_opt/models/optimizer.py
@@ -334,6 +334,7 @@ class Optimizer:
         Cost_Inc = df_base.Cost_Incremental.fillna(df_base.Cost)
         self._preselect(target_num, scenario, discard_thres)
         delta_n = self.delta ** self.selected_df.Life
+
         for t in range(self.T):
             y_past = time_diff[:t].sum() if t > 0 else 0
             cost = 0
@@ -397,15 +398,18 @@ class Optimizer:
                 for t in range(1, self.T)
             ]
             self.solution = pd.DataFrame(sol)
-
             # If the suggested solution is no inferior to the base case, return as solution found
             if self.total_cost < obj_base:
                 return {'status': 'success', 'message': 'Solution found'}
             # If the suggested optimized solution is strictly worse than the base case, replace one candidate measure
-            # with an un-preselscted one and redo optimization
+            # with an un-preselected one and redo optimization
+           
             measure_unchosen = list(set(self.selected_df.Identifier) -
                                     set([x for y in list(self.solution['New Measure']) for x in y]))
-
+            
+            if len(measure_unchosen) == 0:
+                return {'status': 'success', 'message': 'Solution found'}
+            
             measure_ids = [ID in measure_unchosen for ID in self.selected_df.Identifier]
             measure_to_reduce = self.selected_df.iloc[self.selected_df.loc[measure_ids][lookup['data']].idxmin()]
             measure_to_reduce = measure_to_reduce.Identifier

--- a/beam_opt/models/optimizer.py
+++ b/beam_opt/models/optimizer.py
@@ -304,9 +304,9 @@ class Optimizer:
         self.Xoptimal = self.Xmat[Xstar_idx]
         self.Xoptimal_ind = self.Xmat_ind[Xstar_idx]
         self.total_cost = V[0]
-        return self._forward(self.Xoptimal_ind, self.df, scenario)
+        return self._forward(self.Xoptimal_ind, scenario)
     
-    def _forward(self, scenario_selection, measure_df, scenario='Consumption'):
+    def _forward(self, scenario_selection, scenario='Consumption'):
         """
         Perform forward calculation of energy reductions given a configuration of scenario installations.
         """
@@ -314,9 +314,9 @@ class Optimizer:
 
         # Gather the overall reduction, and the reduction for Electricity and Gas
         scenario_df = pd.DataFrame(
-            {scenario: (scenario_selection @ measure_df[lookup['data']].values.reshape([-1, 1])).reshape(-1),
-             'Electricity': (scenario_selection @ measure_df[lookup['electricity']].values.reshape([-1, 1])).reshape(-1),
-             'Gas': (scenario_selection @ measure_df[lookup['gas']].values.reshape([-1, 1])).reshape(-1),
+            {scenario: (scenario_selection @ self.df[lookup['data']].values.reshape([-1, 1])).reshape(-1),
+             'Electricity': (scenario_selection @ self.df[lookup['electricity']].values.reshape([-1, 1])).reshape(-1),
+             'Gas': (scenario_selection @ self.df[lookup['gas']].values.reshape([-1, 1])).reshape(-1),
              'Year': self.timeline}
         ).merge(self.timeline_df, on='Year', how='right').fillna(method='ffill').set_index('Year')
 
@@ -404,7 +404,7 @@ class Optimizer:
             self._prep()
             if scenario_selection:
                 self.df = measure_df # unfiltered dataframe of all scenarios for this property
-                self._forward(scenario_selection, measure_df, scenario)
+                self._forward(scenario_selection, scenario)
                 self.Xoptimal_ind = np.array(scenario_selection)
                 sol = [ # compile solution using unfiltered dataframe
                     {'Year': self.timeline[0], 'New Measure': self.df.Identifier[self.Xoptimal_ind[0]].tolist()}

--- a/beam_opt/utils/parse.py
+++ b/beam_opt/utils/parse.py
@@ -298,15 +298,15 @@ def parse_beam_measures(property_id, elec_emission_rate, gas_emission_rate):
     # Properties will have to add data to the Electricity/Natural Gas Savings, and Electricity/Natural Gas Bill Savings
     # Columns in order to run properly
     # TODO Need to add these extra columns to BEAM, add check that Property has them
-    columns_needed = ['Annual Savings', 'Electricity Savings (kBtu)', 'Natural Gas Savings (kBtu)',
-                      'Electricity Bill Savings', 'Natural Gas Bill Savings']
-    missing_columns = []
-    for column in columns_needed:
-        if column not in state.extra_data:
-            missing_columns.append(column)
-    if missing_columns:
-        return {'status': 'error',
-                'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)}
+    # columns_needed = ['Annual Savings', 'Electricity Savings (kBtu)', 'Natural Gas Savings (kBtu)',
+    #                   'Electricity Bill Savings', 'Natural Gas Bill Savings']
+    # missing_columns = []
+    # for column in columns_needed:
+    #     if column not in state.extra_data:
+    #         missing_columns.append(column)
+    # if missing_columns:
+    #     return {'status': 'error',
+    #             'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)}
 
     property_baseline_data = [[
         str(property_id),                                                   # Building

--- a/beam_opt/utils/parse.py
+++ b/beam_opt/utils/parse.py
@@ -3,6 +3,7 @@
 """
 Provide Various Parsing Functions for Measures formats
 """
+import time
 from django.conf import settings
 import json
 import numpy as np
@@ -10,6 +11,51 @@ import os.path
 import pandas as pd
 import warnings
 import xml.etree.ElementTree as Et
+from seed.models.measures import Measure
+from seed.models.property_measures import PropertyMeasure
+from seed.models.scenarios import Scenario
+
+# TODO: Remove columns that optimizer doesn't use.
+
+MEASURE_DF_COLUMNS = [
+    'Building',
+    'Identifier',
+    'Description',
+    'Cost',
+    'Annual_Saving',
+    'Scenario',
+    'Electricity_CO2',
+    'Gas_CO2',
+    'Total_CO2',
+    'Electricity_Saving',
+    'Gas_Saving',
+    'Electricity_Bill_Saving',
+    'Gas_Bill_Saving',
+    'Category',
+    'Cost_Incremental',
+    'Cost_Bulk',
+    'Life',
+]
+
+BASELINE_DF_COLUMNS = [
+    'Building',
+    'Annual_Bill',
+    'Electricity_CO2',
+    'Gas_CO2',
+    'Total_CO2',
+    'Electricity_Consumption',
+    'Gas_Consumption',
+    'Electricity_Bill',
+    'Gas_Bill',
+]
+
+PROPERTY_STATE_REQUIRED_COLUMNS = [
+    'Annual Savings',
+    'Electricity Savings (kBtu)',
+    'Natural Gas Savings (kBtu)',
+    'Electricity Bill Savings',
+    'Natural Gas Bill Savings'
+]
 
 standalone = getattr(settings, 'STANDALONE', False)
 if not standalone:      # If running with BEAM, import BEAM models
@@ -52,7 +98,8 @@ def parse_measures(request):
         # path = default_storage.save('heart_of_the_swarm.txt', ContentFile(file.read()))
         schema = get_schema(file)  # Determine if it's BuildingSync or HPXML Schema
         if schema == 'BuildingSync':
-            return parse_buildingsync(file, request.data.get('electricity_emission_rate'),
+            return parse_buildingsync(file,
+                                      request.data.get('electricity_emission_rate'),
                                       request.data.get('natural_gas_emission_rate'))
         elif schema == 'HPXML':
             return parse_hpxml(file)
@@ -88,16 +135,6 @@ def parse_hpxml(file):
             'message': '',
             'measure_data': measures_json}  # 'baseline_data':df_baseline}  TODO
 
-
-MEASURE_DF_COLUMNS = ['Building', 'Identifier', 'Description', 'Cost', 'Annual_Saving', 'Scenario',
-                      'Electricity_CO2', 'Gas_CO2', 'Total_CO2', 'Electricity_Saving', 'Gas_Saving',
-                      'Electricity_Bill_Saving', 'Gas_Bill_Saving', 'Category', 'Cost_Incremental', 'Cost_Bulk', 'Life']
-
-BASELINE_DF_COLUMNS = ['Building', 'Annual_Bill', 'Electricity_CO2', 'Gas_CO2', 'Total_CO2',
-                       'Electricity_Consumption', 'Gas_Consumption', 'Electricity_Bill',
-                       'Gas_Bill']
-
-
 def convert_to_kg(emission, starting_units, emission_rate):
     if not emission:
         return 0
@@ -106,7 +143,6 @@ def convert_to_kg(emission, starting_units, emission_rate):
     if starting_units == 'kbtu':
         emission = emission / 1000
     return emission * emission_rate
-
 
 def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
     """
@@ -153,10 +189,11 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
         bulk_cost = m.get('measure_total_first_cost', 0) + m.get('measure_installation_cost', 0) + m.get(
             'measure_material_cost', 0)
         bulk_cost = bulk_cost or None  # Change to None in case costs are not available
+        
         measures.append([
             str(data.get('property_name')),                             # Building ID
             m.get('property_measure_name'),                             # Identifier
-            m.get('name'),                                              # Measure
+            m.get('name'),                                              # Description
             m.get('measure_total_first_cost'),                          # Cost
             best_scenario.get('annual_cost_savings'),                   # Annual_Saving
             best_scenario.get('name'),                                  # Scenario
@@ -165,7 +202,6 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
             electricity_co2 + gas_co2,                                  # Total CO2 use (kbtu)  to (kg)
             best_scenario.get('annual_electricity_savings'),            # Electricity Savings (kbtu)
             best_scenario.get('annual_natural_gas_savings'),            # Gas Savings (kbtu)
-            # # Below 2 don't get used in optimize.py?
             (best_scenario.annual_cost_savings or 0) / 2,               # Electricity Bill Savings
             (best_scenario.annual_cost_savings or 0) / 2,               # Gas Bill Savings
             m.get('category'),                                          # Measure Category Name
@@ -206,107 +242,107 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
             'baseline_data': baseline_json,
             'source': 'BuildingSync'}
 
-
 def parse_beam_measures(property_id, elec_emission_rate, gas_emission_rate):
     """
     Parse BEAM set of Measures and Scenarios, when called through BEAM Analysis Framework
     """
-    pv = PropertyView.objects.filter(id=property_id)
-    if not pv:
+    try:
+        state = PropertyView.objects \
+            .select_related('state') \
+            .get(id=property_id) \
+            .state
+    except PropertyView.DoesNotExist:
         return {'status': 'error', 'message': 'Must pass property_view_id as data parameter'}
-    state = pv.first().state
 
     if elec_emission_rate is None or gas_emission_rate is None:
         return {'status': 'error', 'message': 'Must pass valid fuel type emission rates.'}
+    
+    scenarios = Scenario.objects \
+        .filter(property_state_id=state.id) \
+        .prefetch_related("measures")
+    scenarios = list(scenarios)
 
-    # Get measures and scenarios associated with this property
-    property_measures = PropertyMeasure.objects.filter(property_state_id=state.id).select_related('measure')
-
-    # Process Measures
     measures = []
-    for property_measure in property_measures:
-        measure = property_measure.measure
-        scenarios = property_measure.scenario_set.all()
-        best_scenario = None
-        # Get scenario that has the best savings
-        if scenarios:
-            elec_savings = scenarios[0].annual_electricity_savings
-            ngas_savings = scenarios[0].annual_natural_gas_savings
-
-            for s in scenarios:
-                electricity_savings_diff, gas_savings_diff = 0, 0
-
-                if s.annual_electricity_savings is not None:
-                    electricity_savings_diff = elec_savings - s.annual_electricity_savings
-                if s.annual_natural_gas_savings is not None:
-                    gas_savings_diff = ngas_savings - s.annual_natural_gas_savings
-
-                if electricity_savings_diff + gas_savings_diff >= 0:
-                    elec_savings = s.annual_electricity_savings
-                    ngas_savings = s.annual_natural_gas_savings
-                    best_scenario = s
-
-        if best_scenario is None:
-            # TODO add message that measure was skipped?
+    for scenario in scenarios:
+        scenario_measures = list(scenario.measures.all())
+        if len(scenario_measures) == 0:
             continue
 
-        # Preprocess energy usage data
-        electricty_co2 = convert_to_kg(best_scenario.annual_electricity_energy, 'kbtu', elec_emission_rate)
-        gas_co2 = convert_to_kg(best_scenario.annual_natural_gas_energy, 'kbtu', gas_emission_rate)
+        # aggregate measures
+        best_scenario = _best_scenario(set(scenario_measures), scenarios)
+        if best_scenario is None or best_scenario != scenario:
+            continue
+        cost_total_first = 0
+        cost_mv = 0
+        cost_material = 0
+        max_useful_life = 0
+        for pm in scenario_measures:
+            cost_total_first += (pm.cost_total_first or 0)
+            cost_mv += (pm.cost_mv or 0)
+            cost_material += (pm.cost_material or 0)
+            max_useful_life = max(pm.useful_life or 0, max_useful_life)
 
-        # best_scenario.annual_source_energy = best_scenario.annual_source_energy or 0
-        # best_scenario.annual_site_energy = best_scenario.annual_site_energy or 0
-        # best_scenario_total_co2_use = best_scenario.annual_source_energy + best_scenario.annual_site_energy
-        best_scenario_total_co2_use = electricty_co2 + gas_co2
-        bulk_cost = (property_measure.cost_total_first or 0) + (property_measure.cost_installation or 0) + (
-                property_measure.cost_material or 0)
-        bulk_cost = bulk_cost or None  # Change to None in case costs are 0
+        electricty_co2 = convert_to_kg(
+            scenario.annual_electricity_energy,
+            'kbtu',
+            elec_emission_rate)
+        gas_co2 = convert_to_kg(
+            scenario.annual_natural_gas_energy,
+            'kbtu',
+            gas_emission_rate)
+        total_co2 = electricty_co2 + gas_co2
+        bulk_cost = (cost_total_first + cost_mv + cost_material) or None
+        category_name = scenario.name if len(scenario_measures) > 1 else scenario_measures[0].id
 
         measures.append([
-            str(property_id),                                               # Building ID
-            property_measure.id,                                            # Identifier
-            measure.display_name,                                           # Description
-            property_measure.cost_total_first,                              # Cost
-            best_scenario.annual_cost_savings,                              # Annual_Saving
-            best_scenario.name if best_scenario.name else 'N/A',            # Scenario
-            electricty_co2,                                                 # Electricity CO2 (mmbtu) to (kg)
-            gas_co2,                                                        # Gas CO2 (mmbtu) to (kg)
-            best_scenario_total_co2_use,                                    # Total CO2 Use  (kbtu) to (kg), sum of ^2
-            best_scenario.annual_electricity_savings,                       # Electricity Savings (kbtu)
-            best_scenario.annual_natural_gas_savings,                       # Gas Savings (kbtu)
-                                                                            # # Below 2 don't get used in optimize.py?
-            (best_scenario.annual_cost_savings or 0) / 2,                   # Electricity Bill Savings
-            (best_scenario.annual_cost_savings or 0) / 2,                   # Gas Bill Savings
-            measure.category_display_name,                                  # Measure Category Name
-            property_measure.cost_mv,                                       # Cost Incremental
-            bulk_cost,                                                      # Cost Bulk (Sum of all costs)
-            property_measure.useful_life,                                   # Measure Lifetime
+            str(property_id),                          # Building ID
+            scenario.id,                               # Identifier
+            scenario.name,                             # Description
+            cost_total_first,                          # Cost
+            scenario.annual_cost_savings,              # Annual_Saving
+            scenario.name if scenario.name else 'N/A', # Scenario
+            electricty_co2,                            # Electricity CO2 (mmbtu) to (kg)
+            gas_co2,                                   # Gas CO2 (mmbtu) to (kg)
+            total_co2,                                 # Total CO2 Use  (kbtu) to (kg), sum of ^2
+            scenario.annual_electricity_savings,       # Electricity Savings (kbtu)
+            scenario.annual_natural_gas_savings,       # Gas Savings (kbtu)
+            (scenario.annual_cost_savings or 0) / 2,   # Electricity Bill Savings
+            (scenario.annual_cost_savings or 0) / 2,   # Gas Bill Savings
+            category_name,                             # Measure Category Name
+            cost_mv,                                   # Cost of Measurement and Validation
+            bulk_cost,                                 # Cost Bulk (Sum of all costs)
+            max_useful_life,                           # Measure Lifetime
         ])
-
-        # If any of the Measure data is None, do not add to the set of Measures
-        # if None not in measure:
-        #     measures.append(measure)
-
+    
     df = pd.DataFrame(measures, columns=MEASURE_DF_COLUMNS)
+    # Discard expensive measures with the same effect
+    df = df.loc[df.fillna(np.inf).groupby(['Building', 'Annual_Saving']).Cost.idxmin().fillna(0).astype(int)]
+    df.sort_index(inplace=True)
+    # Discard less effective measures with the same cost
+    df = df.loc[df.fillna(np.inf).groupby(['Building', 'Cost']).Annual_Saving.idxmax().fillna(0).astype(int)]
+    df.sort_index(inplace=True)
 
     # Build dataframe with base information about the property
-    elec_use_co2 = convert_to_kg(state.extra_data.get('Electricity Use - Grid Purchase (kBtu)'), 'kbtu',
-                                 elec_emission_rate)
-    gas_use_co2 = convert_to_kg(state.extra_data.get('Natural Gas Use (kBtu)'), 'kbtu', gas_emission_rate)
+    elec_use_co2 = convert_to_kg(
+        state.extra_data.get('Electricity Use - Grid Purchase (kBtu)'),
+        'kbtu',
+        elec_emission_rate)
+    gas_use_co2 = convert_to_kg(
+        state.extra_data.get('Natural Gas Use (kBtu)'),
+        'kbtu',
+        gas_emission_rate)
     total_use_co2 = elec_use_co2 + gas_use_co2
 
-    # Properties will have to add data to the Electricity/Natural Gas Savings, and Electricity/Natural Gas Bill Savings
-    # Columns in order to run properly
-    # TODO Need to add these extra columns to BEAM, add check that Property has them
-    # columns_needed = ['Annual Savings', 'Electricity Savings (kBtu)', 'Natural Gas Savings (kBtu)',
-    #                   'Electricity Bill Savings', 'Natural Gas Bill Savings']
-    # missing_columns = []
-    # for column in columns_needed:
-    #     if column not in state.extra_data:
-    #         missing_columns.append(column)
-    # if missing_columns:
-    #     return {'status': 'error',
-    #             'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)}
+    missing_columns = []
+    for column in PROPERTY_STATE_REQUIRED_COLUMNS:
+        if column not in state.extra_data:
+            missing_columns.append(column)
+            
+    if missing_columns:
+        return {
+            'status': 'error',
+            'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)
+        }
 
     property_baseline_data = [[
         str(property_id),                                                   # Building
@@ -319,15 +355,17 @@ def parse_beam_measures(property_id, elec_emission_rate, gas_emission_rate):
         state.extra_data.get('Electricity Bill Savings', 0),                # Electricity Bill Savings
         state.extra_data.get('Natural Gas Bill Savings', 0),                # Gas Bill Savings
     ]]
-    df_baseline = pd.DataFrame(property_baseline_data, columns=BASELINE_DF_COLUMNS)
 
+    df_baseline = pd.DataFrame(property_baseline_data, columns=BASELINE_DF_COLUMNS)
     measures_json = json.loads(df.to_json(orient='split'))
     baseline_json = json.loads(df_baseline.to_json(orient='split'))
-    return {'status': 'success',
-            'message': '',
-            'measure_data': measures_json,
-            'baseline_data': baseline_json,
-            'source': 'BEAM'}
+    return {
+        'status': 'success',
+        'message': '',
+        'measure_data': measures_json,
+        'baseline_data': baseline_json,
+        'source': 'BEAM'
+    }
 
 
 # Hard-coded dictionary to reform RMI measures into BuildingSync naming
@@ -416,7 +454,6 @@ def parse_xlsx(file_measure, file_life, bld_list, sync_dict=RMICODE_TO_BUILDINGS
 
     # Discard expensive measures with the same effect
     df = df.loc[df.fillna(np.inf).groupby(['Building', 'Annual_Saving']).Cost.idxmin().fillna(0).astype(int)]
-    df = df.apply(lambda x: x)
     df.sort_index(inplace=True)
     # Discard less effective measures with the same cost
     df = df.loc[df.fillna(np.inf).groupby(['Building', 'Cost']).Annual_Saving.idxmax().fillna(0).astype(int)]
@@ -487,3 +524,35 @@ def group_identifier_rmi(s):
         return 'E-L'
     else:
         return tmp
+    
+def _best_scenario(
+    measures_set: set[PropertyMeasure],
+    scenarios: list[Scenario]
+):
+    """ Select the best Scenario with set of measures that are
+        strictly the measures in measures_set
+    """
+    scenario_contenders = []
+    for scenario in scenarios:
+        if set(scenario.measures.all()) == measures_set:
+            scenario_contenders.append(scenario)
+    
+    best_scenario = None
+    if scenario_contenders:
+        elec_savings = scenario_contenders[0].annual_electricity_savings
+        ngas_savings = scenario_contenders[0].annual_natural_gas_savings
+
+        for s in scenario_contenders:
+            electricity_savings_diff, gas_savings_diff = 0, 0
+
+            if s.annual_electricity_savings is not None:
+                electricity_savings_diff = elec_savings - s.annual_electricity_savings
+            if s.annual_natural_gas_savings is not None:
+                gas_savings_diff = ngas_savings - s.annual_natural_gas_savings
+
+            if electricity_savings_diff + gas_savings_diff >= 0:
+                elec_savings = s.annual_electricity_savings
+                ngas_savings = s.annual_natural_gas_savings
+                best_scenario = s
+        
+    return best_scenario

--- a/beam_opt/utils/parse.py
+++ b/beam_opt/utils/parse.py
@@ -367,16 +367,16 @@ def parse_beam_measures(property_id, elec_emission_rate, gas_emission_rate):
         gas_emission_rate)
     total_use_co2 = elec_use_co2 + gas_use_co2
 
-    missing_columns = []
-    for column in PROPERTY_STATE_REQUIRED_COLUMNS:
-        if column not in state.extra_data:
-            missing_columns.append(column)
-            
-    if missing_columns:
-        return {
-            'status': 'error',
-            'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)
-        }
+    # missing_columns = []
+    # for column in PROPERTY_STATE_REQUIRED_COLUMNS:
+    #     if column not in state.extra_data:
+    #         missing_columns.append(column)
+    #         
+    # if missing_columns:
+    #     return {
+    #         'status': 'error',
+    #         'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)
+    #     }
 
     property_baseline_data = [[
         str(property_id),                                                   # Building

--- a/beam_opt/utils/validate.py
+++ b/beam_opt/utils/validate.py
@@ -95,12 +95,10 @@ def pre_validate_parameters(optimizer: Optimizer, budget, target, penalty, delta
     if len(budget) != len(optimizer.timeline) or len(target) != len(optimizer.timeline):
         errors.append('Invalid input: inconsistent with time line')
     if (np.array(budget) < 0).any():  # budget at each time
-        print('\n\n\nActually budget\n\n\n', flush=True)
-        errors.append('Invalid input: must choose target in [0,1]')
-    if (np.array(target) < 0).any() or (np.array(target) > 1).any():
-        print('\n\n\nActually target\n\n\n', flush=True)
+        errors.append('Invalid input: must choose budget > 0')
+    if (np.array(target) < 0).any():
         # target percentage of consumption/emission to remain at each time
-        errors.append('Invalid input: must choose target in [0,1]')
+        errors.append('Invalid input: must choose target > 0')
     if delta < 0 or delta > 1:  # discount factor
         errors.append('Invalid input: must choose delta in [0,1]')
     if penalty < 0:  # penalty rate for consumption/emission

--- a/beam_opt/utils/validate.py
+++ b/beam_opt/utils/validate.py
@@ -8,6 +8,9 @@ import json
 import numpy as np
 import pandas as pd
 
+from beam_opt.models.data_container import CompleteData
+from beam_opt.models.optimizer import Optimizer
+
 BASELINE_VALIDATION_COLUMNS = ['Annual_Bill', 'Electricity_CO2', 'Gas_CO2', 'Total_CO2', 'Electricity_Consumption',
                                'Gas_Consumption', 'Electricity_Bill', 'Gas_Bill']
 
@@ -15,26 +18,26 @@ MEASURE_VALIDATION_COLUMNS = ['Identifier', 'Cost', 'Annual_Saving', 'Total_CO2'
                               'Electricity_Bill_Saving', 'Gas_Bill_Saving', 'Category', 'Group', 'Index']
 
 
-def validate_complete_data(FullData, ids):
+def validate_complete_data(complete_data: CompleteData, ids):
     """
     Check that a CompleteData object has all of the necessary buildings within it.
     Check that it has all of the columns needed and that those columns are not NaN.
     """
     errors = []
-    # Check that all IDs are in FullData
+    # Check that all Building IDs are in complete_data
     ids = [str(id_) for id_ in ids]
-    if any(bld_ID not in FullData.baseline.Building.to_list() for bld_ID in ids):
+    if any(id_ not in complete_data.baseline.Building.to_list() for id_ in ids):
         errors.append('Invalid Building ID ' + ','.join(
-            list(set(ids) - set(FullData.baseline.Building.to_list()))))
+            list(set(ids) - set(complete_data.baseline.Building.to_list()))))
 
     test_for_nan = True
     # Check that it has all of the Columns needed
-    baseline_columns = list(FullData.baseline.columns)
+    baseline_columns = list(complete_data.baseline.columns)
     baseline_columns_diff = list(set(BASELINE_VALIDATION_COLUMNS) - set(baseline_columns))
     if baseline_columns_diff:
         test_for_nan = False
         errors.append('Baseline data is missing columns: %s' % ', '.join(baseline_columns_diff))
-    measure_columns = list(FullData.measure_data.columns)  # TODO Convert this to return just the DF in all locations
+    measure_columns = list(complete_data.measure_data.columns)  # TODO Convert this to return just the DF in all locations
     measure_columns_diff = list(set(MEASURE_VALIDATION_COLUMNS) - set(measure_columns))
     if measure_columns_diff:
         test_for_nan = False
@@ -43,13 +46,13 @@ def validate_complete_data(FullData, ids):
     # Only test for NaN values if all columns are available:
     if test_for_nan:
         # Should already be checked by pre-parsing
-        sub_df = FullData.baseline.loc[FullData.baseline.Building.notna(), BASELINE_VALIDATION_COLUMNS]
+        sub_df = complete_data.baseline.loc[complete_data.baseline.Building.notna(), BASELINE_VALIDATION_COLUMNS]
         nan_values = sub_df.isna().values.any()
         if nan_values:
             cols_with_nans = sub_df.columns[nan_values].tolist()[0]
             errors.append('Missing Data in Baseline dataset in columnns: ' + ', '.join(cols_with_nans))
 
-        measures_result = FullData.get_measure_data(ids)
+        measures_result = complete_data.get_measure_data(ids)
         measures_df = pd.read_json(json.dumps(measures_result['measure_data']), orient='split')
 
         sub_df = measures_df.loc[measures_df.Building.notna(), ['Identifier', 'Cost', 'Category', 'Group', 'Index']]
@@ -82,18 +85,20 @@ def validate_complete_data(FullData, ids):
     return errors if errors else None
 
 
-def pre_validate_parameters(OPT, budget, target, penalty, delta, scenario):
+def pre_validate_parameters(optimizer: Optimizer, budget, target, penalty, delta, scenario):
     """
     Check that all of the parameters are valid
     """
     errors = []
     if scenario not in ['Consumption', 'Emission']:
         errors.append('Invalid Scenario. Must choose between Consumption/Emission')
-    if len(budget) != len(OPT.timeline) or len(target) != len(OPT.timeline):
+    if len(budget) != len(optimizer.timeline) or len(target) != len(optimizer.timeline):
         errors.append('Invalid input: inconsistent with time line')
     if (np.array(budget) < 0).any():  # budget at each time
+        print('\n\n\nActually budget\n\n\n', flush=True)
         errors.append('Invalid input: must choose target in [0,1]')
     if (np.array(target) < 0).any() or (np.array(target) > 1).any():
+        print('\n\n\nActually target\n\n\n', flush=True)
         # target percentage of consumption/emission to remain at each time
         errors.append('Invalid input: must choose target in [0,1]')
     if delta < 0 or delta > 1:  # discount factor
@@ -102,17 +107,17 @@ def pre_validate_parameters(OPT, budget, target, penalty, delta, scenario):
         errors.append('Invalid input: must choose nonnegative penalty')
 
     # Check that Target is Achievable
-    timeline_df = pd.DataFrame(np.arange(OPT.timeline[0], OPT.timeline[-1] + 1), columns=['Year'])
-    target_df = pd.DataFrame({'Target': target, 'Year': OPT.timeline}
+    timeline_df = pd.DataFrame(np.arange(optimizer.timeline[0], optimizer.timeline[-1] + 1), columns=['Year'])
+    target_df = pd.DataFrame({'Target': target, 'Year': optimizer.timeline}
                              ).merge(timeline_df, on='Year', how='right').fillna(method='ffill').set_index('Year')
 
-    if scenario in OPT.lookups:
-        lookup = OPT.lookups[scenario]
+    if scenario in optimizer.lookups:
+        lookup = optimizer.lookups[scenario]
         if np.isinf(penalty):
             # Check whether target is achievable
-            target = target_df.Target * OPT.baseline[lookup['optimize']].iloc[0]
-            max_reduction = OPT.df.groupby('Group')[lookup['data']].max().sum()
-            ind = getattr(OPT, lookup['target']) < (OPT.baseline[lookup['optimize']] - max_reduction)
+            target = target_df.Target * optimizer.baseline[lookup['optimize']].iloc[0]
+            max_reduction = optimizer.df.groupby('Group')[lookup['data']].max().sum()
+            ind = getattr(optimizer, lookup['target']) < (optimizer.baseline[lookup['optimize']] - max_reduction)
             if any(ind):
                 errors.append('%s target too low to fulfill. See Violating years for detail' % scenario)
                 # return{'status':'error','message':'Consumption target too low to fulfill. See violating_years for
@@ -125,12 +130,12 @@ def pre_validate_parameters(OPT, budget, target, penalty, delta, scenario):
     return errors if errors else None
 
 
-def post_validate_parameters(OPT, scenario):
+def post_validate_parameters(optimizer: Optimizer, scenario):
     """
     Check that consumption/emission targets were set sucessfully
     """
-    lookup = OPT.lookups[scenario]
+    lookup = optimizer.lookups[scenario]
     errors = []
-    if not hasattr(OPT, lookup['target']):
+    if not hasattr(optimizer, lookup['target']):
         errors.append('Must set Target before calling Optimization')
     return errors if errors else None

--- a/beam_opt/utils/validate.py
+++ b/beam_opt/utils/validate.py
@@ -68,9 +68,15 @@ def validate_complete_data(FullData, ids):
                    'Electricity_Bill_Saving': 'annual_electricity_savings',
                    'Gas_Bill_Saving': 'annual_natural_gas_savings'
                    }
-        nan_values = sub_df.isna().values.any()
-        if nan_values:
-            cols_with_nans = sub_df.columns[nan_values].tolist()[0]
+
+        nan_values = sub_df.isna().values
+        has_nan = [False for i in range(len(sub_df.columns))]
+        for row in range(len(nan_values)):
+            for col in range(len(nan_values[row])):
+                if nan_values[row, col]: has_nan[col] = True
+
+        if sub_df.isna().values.any():
+            cols_with_nans = sub_df.columns[has_nan].tolist()
             errors.append('Missing data in one or more Scenarios: ' + ', '.join([mapping[i] for i in cols_with_nans]))
 
     return errors if errors else None


### PR DESCRIPTION
# Sam: Parsing Scenarios to send in to the optimizer.

#### Any background context you want to provide?

Before this PR, the optimizer was optimizing over individual measures. We wanted a way to have the optimizer use bundles of measures (as defined by a Scenario).

#### What's this PR do?

With this PR, the optimizer will consider Scenarios as bundles of Measures and optimize for these instead. One problem that we ran into while working was how the optimizer should handle the case of Scenarios that have measures which overlap each other (Scenario A has measures X and Scenario B has measure X).

This implementation will remove the scenarios iteratively selecting for the measure which is more favorable by savings by removing the less favorable scenarios. This ends when the set of scenarios are each compatible with each other. (see `_reduce_scenarios` in `parse.py`)

### How should this be manually tested?

See the instructions for testing under "Analysis Results Display & Recalculation". You should seed that the analysis result has selected a Scenarios rather than individual measures.

#### What are the relevant tickets?

https://clearlyenergy.plan.io/issues/1420?pn=1#change-4870

# Itai - Analysis Results Display & Recalculation

### What's this PR do?
#### Forward Recalculation
The forward recalculation part of `_optimize()` has been pulled out to another function called `_forward()`. 

The parameter `scenario_selection` is a 2d array of `True | False` in sorted order of scenario ID. Each row is a period from the emission scenario and each column indicates whether or not that scenario is installed in that period. In a normal run of the optimizer, `self.Xoptimal_ind` is passed in for `scenario_selection`.

In a normal run of the optimizer, `self.df` is filtered down in `parse.py` and in `_preselect`. In a recalculation run of the optimizer, `self.df` will be unfiltered and contain all scenarios from the property. In all cases, self.df will be sorted in ascending scenario id order (programmatically, `self.df.sort_values(by='Identifier')`)

#### Target Calculation Change
Before, the target was calculated by multiplying a standardized emissions target (i.e. the first period is 100%, the second period is 100% - the percent change from first, etc...) with the baseline emissions of the building in the first period. This lead the optimizer to believe that the building was never exceeding the emissions target in first period.

Now, the target is not standardized and is passed in as raw mtCO2e. They are converted to kg in `set_parameters()`. The `pre_validate_parameters()` function in `validate.py` has been modified to allow the value of the target to be greater than 1.

### How should this be manually tested?
#### Recalculation
On an existing analysis, interact with the UI-grids to modify the scenario configuration. For instance, in the unselected scenarios table, add a year to one of the scenarios, and check its checkbox. Hit recalculate, and use the notification in the top right to go to the analyses page. The new analysis should process very quickly since no optimization is performed, only some arithmetic recalculation. The new analysis will have the same name as the original, but with  (modified) added to the end. This selected scenarios table of this new analysis should reflect the changes you made to the UI-grids in the original.

#### Target Change
Run a new analysis on a building with an arbitrarily high penalty (`50,000` is a great test value). Analyses without these changes will not select money-losing scenarios in the first period, even if the emissions are way over the target. Analyses with this change will select scenarios in order to reach the target in the first period to avoid the high penalties.

### What are the relevant tickets?
https://clearlyenergy.plan.io/issues/1422