### PR TITLE
enhancement: Decrease Execution time of Optimization

### DIFF
--- a/beam_opt/models/optimizer.py
+++ b/beam_opt/models/optimizer.py
@@ -4,12 +4,15 @@
 :copyright (c) 2014 - 2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Department of Energy) and contributors. All rights reserved.  # NOQA
 :author
 """
+
 import json
 import numpy as np
 import pandas as pd
 import itertools
 
 from beam_opt.models.data_container import CompleteData
+
+pr = cProfile.Profile()
 
 class Optimizer:
     lookups = {

--- a/beam_opt/utils/parse.py
+++ b/beam_opt/utils/parse.py
@@ -3,8 +3,6 @@
 """
 Provide Various Parsing Functions for Measures formats
 """
-from copy import copy
-import time
 from django.conf import settings
 import json
 import numpy as np
@@ -12,8 +10,6 @@ import os.path
 import pandas as pd
 import warnings
 import xml.etree.ElementTree as Et
-from seed.models.measures import Measure
-from seed.models.property_measures import PropertyMeasure
 from seed.models.scenarios import Scenario
 from seed.serializers.scenarios import ScenarioSerializer
 
@@ -61,7 +57,7 @@ PROPERTY_STATE_REQUIRED_COLUMNS = [
 
 standalone = getattr(settings, 'STANDALONE', False)
 if not standalone:      # If running with BEAM, import BEAM models
-    from seed.models import PropertyMeasure, PropertyView
+    from seed.models import PropertyView
     from seed.building_sync.building_sync import BuildingSync
     from seed.hpxml.hpxml import HPXML
 
@@ -100,6 +96,7 @@ def parse_measures(request):
         # path = default_storage.save('heart_of_the_swarm.txt', ContentFile(file.read()))
         schema = get_schema(file)  # Determine if it's BuildingSync or HPXML Schema
         if schema == 'BuildingSync':
+            # TODO: can't use BS path until it's been converted to using time-dependent data
             return parse_buildingsync(file,
                                       request.data.get('electricity_emission_rate'),
                                       request.data.get('natural_gas_emission_rate'))
@@ -108,9 +105,10 @@ def parse_measures(request):
         else:
             return {'status': 'error', 'message': 'Could not parse XML. No valid Schema found.'}
     elif extension is None and not standalone:      # Parse BEAM Files
+        # TODO: make sure we have this data in the request
         return parse_beam_measures(request.data.get('property_id'),
-                                   float(request.data.get('electricity_emission_rate')),
-                                   float(request.data.get('natural_gas_emission_rate')))
+                                   request.data.get('emission_rates'),
+                                   request.data.get('timeline'))
     else:
         return {'status': 'error', 'message': 'No Valid Parse method found'}
 
@@ -137,14 +135,17 @@ def parse_hpxml(file):
             'message': '',
             'measure_data': measures_json}  # 'baseline_data':df_baseline}  TODO
 
+
 def convert_to_kg(emission, starting_units, emission_rate):
     if not emission:
         return 0
+
     emission = float(emission)
     # Assume emission is in mmbtu, and convert to if starting units is kbtu
     if starting_units == 'kbtu':
         emission = emission / 1000
     return emission * emission_rate
+
 
 def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
     """
@@ -171,8 +172,8 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
         # Get scenario that has the best savings
         for scenario in filtered_scenarios:
             elec_saving_diff, ngas_saving_diff = 0, 0
-            annual_elec_savings = scenario.get('annual_electricity_savings')
-            annual_ngas_savings = scenario.get('annual_natural_gas_savings')
+            annual_elec_savings = scenario.get('annual_electricity_energy')
+            annual_ngas_savings = scenario.get('annual_natural_gas_energy')
             if annual_elec_savings is not None:
                 elec_saving_diff = elec_savings - annual_elec_savings
             if annual_ngas_savings is not None:
@@ -186,12 +187,12 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
             # TODO add message that measure was skipped?
             continue
 
-        electricity_co2 = convert_to_kg(best_scenario.annaul_electricity_energy, 'kbtu', elec_emission_rate)
-        gas_co2 = convert_to_kg(best_scenario.annual_natural_gas_energy, 'kbtu', gas_emission_rate)
+        electricity_co2 = convert_to_kg(best_scenario.annual_electricity_energy, 'mmbtu', elec_emission_rate)
+        gas_co2 = convert_to_kg(best_scenario.annual_natural_gas_energy, 'mmbtu', gas_emission_rate)
         bulk_cost = m.get('measure_total_first_cost', 0) + m.get('measure_installation_cost', 0) + m.get(
             'measure_material_cost', 0)
         bulk_cost = bulk_cost or None  # Change to None in case costs are not available
-        
+
         measures.append([
             str(data.get('property_name')),                             # Building ID
             m.get('property_measure_name'),                             # Identifier
@@ -201,9 +202,9 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
             best_scenario.get('name'),                                  # Scenario
             electricity_co2,                                            # Electricity CO2 (mmbtu)  to (kg)
             gas_co2,                                                    # Gas CO2 (mmbtu)  to (kg)
-            electricity_co2 + gas_co2,                                  # Total CO2 use (kbtu)  to (kg)
-            best_scenario.get('annual_electricity_savings'),            # Electricity Savings (kbtu)
-            best_scenario.get('annual_natural_gas_savings'),            # Gas Savings (kbtu)
+            electricity_co2 + gas_co2,                                  # Total CO2 use (mmbtu)  to (kg)
+            best_scenario.get('annual_electricity_energy'),             # Electricity Savings (mmbtu)
+            best_scenario.get('annual_natural_gas_energy'),             # Gas Savings (mmbtu)
             (best_scenario.annual_cost_savings or 0) / 2,               # Electricity Bill Savings
             (best_scenario.annual_cost_savings or 0) / 2,               # Gas Bill Savings
             m.get('category'),                                          # Measure Category Name
@@ -221,17 +222,17 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
                 'message': 'No Baseline Scenario found for this Property. Please create.'}
 
     baseline_scenario = baseline_scenario[0]
-    electricity_co2 = convert_to_kg(baseline_scenario.annual_electricity_energy, 'kbtu', elec_emission_rate)
-    gas_co2 = convert_to_kg(baseline_scenario.annual_natural_gas_energy, 'kbtu', gas_emission_rate)
+    electricity_co2 = convert_to_kg(baseline_scenario.annual_electricity_energy, 'mmbtu', elec_emission_rate)
+    gas_co2 = convert_to_kg(baseline_scenario.annual_natural_gas_energy, 'mmbtu', gas_emission_rate)
     data = [[
         str(data.get('property_name')),                                     # Building ID
         baseline_scenario.get('annual_cost_savings'),                       # Annual_Saving
         baseline_scenario.get('name'),                                      # Scenario
         electricity_co2,                                                    # Electricity CO2 (mmbtu)  to (kg)
         gas_co2,                                                            # Gas CO2 (mmbtu)  to (kg)
-        electricity_co2 + gas_co2,                                          # Total CO2 use (kbtu)  to (kg)
-        baseline_scenario.get('annual_electricity_savings'),                # Electricity Savings (kbtu)
-        baseline_scenario.get('annual_natural_gas_savings'),                # Gas Savings (kbtu)
+        electricity_co2 + gas_co2,                                          # Total CO2 use (mmbtu)  to (kg)
+        baseline_scenario.get('annual_electricity_energy'),                 # Electricity Savings (mmbtu)
+        baseline_scenario.get('annual_natural_gas_energy'),                 # Gas Savings (mmbtu)
     ]]
 
     df_baseline = pd.DataFrame(data, columns=BASELINE_DF_COLUMNS)
@@ -244,6 +245,7 @@ def parse_buildingsync(file, elec_emission_rate, gas_emission_rate):
             'baseline_data': baseline_json,
             'source': 'BuildingSync'}
 
+
 def _reduce_scenarios(scenarios_data):
     """ Removes scenarios that overlap in measures. Criteria for picking between
         two Scenarios is defined by _worse_scenario.
@@ -253,14 +255,14 @@ def _reduce_scenarios(scenarios_data):
     """
     scenario_lookup = {s['id']: (s, set([m['display_name'] for m in s['measures']])) for s in scenarios_data}
     results = set()
-    
+
     def _reduce_scenarios_rec(scenario_ids: list):
         if len(scenario_ids) == 0:
             return
         if len(scenario_ids) == 1:
             results.add(scenario_ids[0])
             return
-        
+
         l_scenario, l_measures = scenario_lookup[scenario_ids[0]]
         worse_id = None
         for s_id in scenario_ids[1:]:
@@ -268,33 +270,51 @@ def _reduce_scenarios(scenarios_data):
             if not l_measures.isdisjoint(r_measures):
                 worse_id = _worse_scenario(l_scenario, r_scenario)['id']
                 break
-        
-        if worse_id == None:
+
+        if worse_id is None:
             results.add(l_scenario['id'])
             scenario_ids = scenario_ids[1:]
         else:
             scenario_ids = [_id for _id in scenario_ids if _id != worse_id]
 
         _reduce_scenarios_rec(scenario_ids)
-    
+
     _reduce_scenarios_rec([s['id'] for s in scenarios_data])
     return [scenario_lookup[s_id][0] for s_id in results]
 
-def parse_beam_measures(property_id, elec_emission_rate, gas_emission_rate):
+
+def validate_emission_rates(emission_rates: dict) -> bool:
+    """Validate that there are emission rates for each time series
+
+    :param emission_rates: dict of {year: {fuel type: fuel rate}}
+
+    :returns: bool
+    """
+    for year, rates in emission_rates.items():
+        for fuel_type, fuel_rate in rates.items():
+            if fuel_rate is None:
+                return False
+    return True
+
+
+def parse_beam_measures(property_view_id: int, emission_rates: dict, timeline: list):
     """
     Parse BEAM set of Measures and Scenarios, when called through BEAM Analysis Framework
-    """
-    try:
-        state = PropertyView.objects \
-            .select_related('state') \
-            .get(id=property_id) \
-            .state
-    except PropertyView.DoesNotExist:
-        return {'status': 'error', 'message': 'Must pass property_view_id as data parameter'}
 
-    if elec_emission_rate is None or gas_emission_rate is None:
+    :param int property_view_id: PropertyView object id
+    :param dict emission_rates: mapping of emission rates to year
+    :param list timeline: time steps used in emission rates
+
+    :returns: dict of parsed measure and baseline data
+    """
+    pv = PropertyView.objects.select_related('state').get(id=property_view_id)
+    if not pv:
+        return {'status': 'error', 'message': 'Must pass property_view_id as data parameter'}
+    state = pv.state
+
+    if not validate_emission_rates(emission_rates):
         return {'status': 'error', 'message': 'Must pass valid fuel type emission rates.'}
-    
+
     scenarios = Scenario.objects \
         .filter(property_state_id=state.id) \
         .prefetch_related("measures")
@@ -316,62 +336,67 @@ def parse_beam_measures(property_id, elec_emission_rate, gas_emission_rate):
             cost_material += (pm['cost_material'] or 0)
             max_useful_life = max(pm['useful_life'] or 0, max_useful_life)
 
-        electricty_co2 = convert_to_kg(
-            scenario['annual_electricity_energy'],
-            'kbtu',
-            elec_emission_rate)
-        gas_co2 = convert_to_kg(
-            scenario['annual_natural_gas_energy'],
-            'kbtu',
-            gas_emission_rate)
-        total_co2 = electricty_co2 + gas_co2
         bulk_cost = (cost_total_first + cost_mv + cost_material) or None
         category_name = scenario['name'] if len(scenario_measures) > 1 else scenario_measures[0]['id']
 
+        # Calculate CO2 at each time interval
+        elec_co2_list = []
+        gas_co2_list = []
+        total_co2 = []
+        for time in timeline:
+            elec_rate = emission_rates['electricity'][time]
+            gas_rate = emission_rates['natural_gas'][time]
+            elec_co2 = convert_to_kg(scenario['annual_electricity_energy'], 'mmbtu', elec_rate)
+            gas_co2 = convert_to_kg(scenario['annual_natural_gas_energy'], 'mmbtu', gas_rate)
+            elec_co2_list.append(elec_co2)
+            gas_co2_list.append(gas_co2)
+            total_co2.append(elec_co2 + gas_co2)
+
         measures.append([
-            str(property_id),                                # Building ID
-            scenario['id'],                                  # Identifier
-            scenario['name'],                                # Description
-            cost_total_first,                                # Cost
-            scenario['annual_cost_savings'],                 # Annual_Saving
-            scenario['name'] if scenario['name'] else 'N/A', # Scenario
-            electricty_co2,                                  # Electricity CO2 (mmbtu) to (kg)
-            gas_co2,                                         # Gas CO2 (mmbtu) to (kg)
-            total_co2,                                       # Total CO2 Use  (kbtu) to (kg), sum of ^2
-            scenario['annual_electricity_savings'],          # Electricity Savings (kbtu)
-            scenario['annual_natural_gas_savings'],          # Gas Savings (kbtu)
-            (scenario['annual_cost_savings'] or 0) / 2,      # Electricity Bill Savings
-            (scenario['annual_cost_savings'] or 0) / 2,      # Gas Bill Savings
-            category_name,                                   # Measure Category Name
-            cost_mv,                                         # Cost of Measurement and Validation
-            bulk_cost,                                       # Cost Bulk (Sum of all costs)
-            max_useful_life,                                 # Measure Lifetime
+            str(property_view_id),                                              # Building ID
+            scenario['id'],                                                     # Identifier
+            scenario['name'],                                                   # Description
+            cost_total_first,                                                   # Cost
+            scenario['annual_cost_savings'],                                    # Annual_Saving
+            scenario['name'] if scenario['name'] else 'N/A',                    # Scenario
+            elec_co2_list,                                                      # Electricity CO2 (mmbtu) to (kg)
+            gas_co2_list,                                                       # Gas CO2 (mmbtu) to (kg)
+            total_co2,                                                          # Sum of Fuel Uses CO2 (kg)
+            [scenario['annual_electricity_energy']] * len(timeline),            # Electricity Savings (mmbtu)
+            [scenario['annual_natural_gas_energy']] * len(timeline),            # Gas Savings (mmbtu)
+            (scenario['annual_cost_savings'] or 0) / 2,                         # Electricity Bill Savings
+            (scenario['annual_cost_savings'] or 0) / 2,                         # Gas Bill Savings
+            category_name,                                                      # Measure Category Name
+            cost_mv,                                                            # Cost of Measurement and Validation
+            bulk_cost,                                                          # Cost Bulk (Sum of all costs)
+            max_useful_life,                                                    # Measure Lifetime
         ])
-    
+
     df = pd.DataFrame(measures, columns=MEASURE_DF_COLUMNS)
+
     # Discard expensive measures with the same effect
     df = df.loc[df.fillna(np.inf).groupby(['Building', 'Annual_Saving']).Cost.idxmin().fillna(0).astype(int)]
     df.sort_index(inplace=True)
+
     # Discard less effective measures with the same cost
     df = df.loc[df.fillna(np.inf).groupby(['Building', 'Cost']).Annual_Saving.idxmax().fillna(0).astype(int)]
     df.sort_index(inplace=True)
 
-    # Build dataframe with base information about the property
-    elec_use_co2 = convert_to_kg(
-        state.extra_data.get('Electricity Use - Grid Purchase (kBtu)'),
-        'kbtu',
-        elec_emission_rate)
-    gas_use_co2 = convert_to_kg(
-        state.extra_data.get('Natural Gas Use (kBtu)'),
-        'kbtu',
-        gas_emission_rate)
+    # ###  Build dataframe with base information about the property
+    elec_rates = emission_rates['electricity']
+    gas_rates = emission_rates['natural_gas']
+    base_elec_rate = elec_rates[timeline[0]]
+    base_gas_rate = gas_rates[timeline[0]]
+
+    elec_use_co2 = convert_to_kg(state.extra_data.get('Electricity Use - Grid Purchase (kBtu)'), 'kbtu', base_elec_rate)
+    gas_use_co2 = convert_to_kg(state.extra_data.get('Natural Gas Use (kBtu)'), 'kbtu', base_gas_rate)
     total_use_co2 = elec_use_co2 + gas_use_co2
 
     # missing_columns = []
     # for column in PROPERTY_STATE_REQUIRED_COLUMNS:
     #     if column not in state.extra_data:
     #         missing_columns.append(column)
-    #         
+    #
     # if missing_columns:
     #     return {
     #         'status': 'error',
@@ -379,13 +404,13 @@ def parse_beam_measures(property_id, elec_emission_rate, gas_emission_rate):
     #     }
 
     property_baseline_data = [[
-        str(property_id),                                                   # Building
+        str(property_view_id),                                              # Building
         state.extra_data.get('Annual Savings', 0),                          # Annual_Saving
         elec_use_co2,                                                       # Electricity CO2 (kbtu) to (kg)
         gas_use_co2,                                                        # Gas CO2 (kbtu) to (kg)
         total_use_co2,                                                      # Total sum of above fuels
-        state.extra_data.get('Electricity Savings (kbtu)', 0),              # Electricity Savings
-        state.extra_data.get('Natural Gas Savings (kbtu)', 0),              # Gas Savings
+        state.extra_data.get('Electricity Savings (kbtu)', 0) / 1000,       # Electricity Savings (mmbtu)
+        state.extra_data.get('Natural Gas Savings (kbtu)', 0) / 1000,       # Gas Savings (mmbtu)
         state.extra_data.get('Electricity Bill Savings', 0),                # Electricity Bill Savings
         state.extra_data.get('Natural Gas Bill Savings', 0),                # Gas Bill Savings
     ]]
@@ -559,6 +584,7 @@ def group_identifier_rmi(s):
     else:
         return tmp
 
+
 def _worse_scenario(left_scenario, right_scenario):
     """ Select the scenario with lower energy savings. If tie, return left scenario
 
@@ -572,3 +598,4 @@ def _worse_scenario(left_scenario, right_scenario):
         + right_scenario['annual_natural_gas_savings']
 
     return left_scenario if left_savings <= right_savings else right_scenario
+

--- a/beam_opt/utils/validate.py
+++ b/beam_opt/utils/validate.py
@@ -37,7 +37,9 @@ def validate_complete_data(complete_data: CompleteData, ids):
     if baseline_columns_diff:
         test_for_nan = False
         errors.append('Baseline data is missing columns: %s' % ', '.join(baseline_columns_diff))
-    measure_columns = list(complete_data.measure_data.columns)  # TODO Convert this to return just the DF in all locations
+
+    # TODO: Convert this to return just the DF in all locations
+    measure_columns = list(complete_data.measure_data.columns)
     measure_columns_diff = list(set(MEASURE_VALIDATION_COLUMNS) - set(measure_columns))
     if measure_columns_diff:
         test_for_nan = False
@@ -62,7 +64,7 @@ def validate_complete_data(complete_data: CompleteData, ids):
             errors.append('Missing data in one or more Measures: ' + ', '.join(cols_with_nans))
 
         sub_df = measures_df.loc[measures_df.Building.notna(),
-                                 ['Annual_Saving', 'Total_CO2', 'Electricity_Saving',
+                                 ['Annual_Saving', 'Electricity_Saving',
                                   'Gas_Saving', 'Electricity_Bill_Saving', 'Gas_Bill_Saving']]
         mapping = {'Annual_Saving': 'annual_cost_savings',
                    'Total_CO2': 'annual_electricity_energy/annual_natural_gas_energy',
@@ -76,7 +78,8 @@ def validate_complete_data(complete_data: CompleteData, ids):
         has_nan = [False for i in range(len(sub_df.columns))]
         for row in range(len(nan_values)):
             for col in range(len(nan_values[row])):
-                if nan_values[row, col]: has_nan[col] = True
+                if nan_values[row, col]:
+                    has_nan[col] = True
 
         if sub_df.isna().values.any():
             cols_with_nans = sub_df.columns[has_nan].tolist()
@@ -137,3 +140,4 @@ def post_validate_parameters(optimizer: Optimizer, scenario):
     if not hasattr(optimizer, lookup['target']):
         errors.append('Must set Target before calling Optimization')
     return errors if errors else None
+


### PR DESCRIPTION
#### What's this PR do?

There were multiple redundant and unused computations in `_optimize`. Most of these computations have been identified and reduced or eliminated.

The optimizer also used pandas Series objects for doing some computations. These computations were converted to use the underlying numpy arrays which significantly reduces computation time for vector operations.

Before these changes, [this analysis on DC Staging](https://dc-staging.beam-portal.org/app/#/analyses/194/runs/640) took nearly 8 minutes. Before changes were made, I benchmarked this analysis on my system and benchmarked 4 minutes. After the changes made here, the entire computation takes approximately 1 minute to complete on my system. The result of the computation appears identical (optimizer currently has no programmatic tests).

#### Manual Testing

Do the following before applying the changes made by this PR to get a benchmark for execution time.
1. Copy the [Emission Scenario](https://dc-staging.beam-portal.org/app/#/accounts/359/emission_scenarios/9) used for the previously mentioned analysis.
2.  Upload the following Measures/Scenarios to a test building [BEAMopt_bldg3.xlsx](https://github.com/ClearlyEnergy/BEAM-OPT/files/14089101/BEAMopt_bldg3.xlsx)
3. Copy the analysis input (budget per year, selected emission scenario) used in the analysis (linked above).
4. Run the analysis and note the time to complete.
5. Apply the changes from this PR and run the same analysis again. Note difference in time. Ensure that test output is same (same Scenarios selected, reduced emissions, etc)

#### What are the relevant tickets?

https://clearlyenergy-inc.monday.com/boards/5290716771/pulses/5839414191