### PR TITLE
Account for gas reduction below zero

### DIFF
--- a/beam_opt/models/optimizer.py
+++ b/beam_opt/models/optimizer.py
@@ -15,7 +15,7 @@ import itertools
 from beam_opt.models.data_container import CompleteData
 
 LOGGER = logging.getLogger(__name__)
-ACCEPT_FIRST_SOLUTION = False
+ACCEPT_FIRST_SOLUTION = True
 LOOKUP = {
     'Consumption': {
         'data': 'Total_Saving',

--- a/beam_opt/models/optimizer.py
+++ b/beam_opt/models/optimizer.py
@@ -13,9 +13,8 @@ import itertools
 
 from beam_opt.models.data_container import CompleteData
 
-
-class Optimizer:
-    lookups = {
+    
+LOOKUP = {
         'Consumption': {
             'data': 'Total_Saving',
             'target': 'consumption_target',
@@ -39,6 +38,8 @@ class Optimizer:
             'baseline_gas': 'Gas_CO2',
         }
     }
+
+class Optimizer:
 
     def __init__(self, complete_data: CompleteData, bldg_id, timeline: list):
         bldg_id = [str(bldg_id)]
@@ -105,8 +106,6 @@ class Optimizer:
         self.solution = None
 
     def set_parameters(self, budget, target, penalty, delta, scenario='Consumption'):
-        lookup = self.lookups[scenario]
-
         self.delta = delta
         self.budget = np.array(budget)
         self.penalty = penalty
@@ -114,46 +113,47 @@ class Optimizer:
         # Set target attribute
         target_df = pd.DataFrame({'Target': target, 'Year': self.timeline})
         target_df = target_df.merge(self.timeline_df, on='Year', how='right').fillna(method='ffill').set_index('Year')
-        setattr(self, lookup['target'], target_df.Target * 1000) # target_df.Target is in mtCO2e, convert to kg
+        setattr(self, LOOKUP[scenario]['target'], target_df.Target * 1000) # target_df.Target is in mtCO2e, convert to kg
 
         return {'status': 'success', 'message': ''}
 
     def _preselect(self, target_num=15, scenario='Consumption', discard_thres=1e-3):
         # Discard measures with negative electricity and gas savings
-        lookup = self.lookups[scenario]
         for time in self.timeline:
-            self.selected_df = self.measure_df[(self.measure_df[lookup['electricity'] + ' ' + str(time)] >= 0) |
-                                       self.measure_df[lookup['gas'] + ' ' + str(time)] >= 0]
+            self.selected_df = self.measure_df[(self.measure_df[col_label_by_year(LOOKUP[scenario]['electricity'],time)] >= 0) |
+                                       self.measure_df[col_label_by_year(LOOKUP[scenario]['gas'],time)] >= 0]
 
-        # Pick measures meeting certain financial standards
-        ratio = np.empty(target_num)
+
+        # Discard measures whose annual saving is less than discard_thres * baseline expenditure
         if self.selected_df.shape[0] > target_num:
-            # Discard measures whose annual saving is less than discard_thres * baseline expenditure
             self.selected_df = self.selected_df.loc[self.selected_df.Annual_Saving >=
                                                     (discard_thres * self.baseline.Annual_Bill.values.min())]
-            if self.selected_df.shape[0] > target_num:
-                # Select measures by cost efficiency within each exclusion group
-                self.selected_df = self.selected_df.groupby('Group', group_keys=False).apply(
-                    lambda x: pick_cost_efficiency(x, self.timeline, lookup))
-                if self.selected_df.shape[0] > target_num:
-                    # Select measures by saving/cost ratios
-                    # TODO: with Total_CO2 being expanded, how to select? Using initial year as temp solution
-                    value = self.selected_df[lookup['data'] + ' ' + str(self.timeline[0])] * self.selected_df.Life
-                    ratio = value / self.selected_df.Cost
-                    ratio = ratio.sort_values(ascending=False).dropna()[:target_num]
-                    self.selected_df = self.selected_df.loc[ratio.index]
+        
+        # Select measures by cost efficiency within each exclusion group
+        if self.selected_df.shape[0] > target_num:
+            self.selected_df = self.selected_df.groupby('Group', group_keys=False).apply(
+                lambda x: pick_cost_efficiency(x, self.timeline, scenario))
+        
+        # Select measures by saving/cost ratios
+        ratio = np.empty(target_num)
+        if self.selected_df.shape[0] > target_num:
+            # TODO: with Total_CO2 being expanded, how to select? Using initial year as temp solution
+            value = self.selected_df[col_label_by_year(LOOKUP[scenario]['data'],self.timeline[0])] * self.selected_df.Life
+            ratio = value / self.selected_df.Cost
+            ratio = ratio.sort_values(ascending=False).dropna()[:target_num]
+            self.selected_df = self.selected_df.loc[ratio.index]
 
         # Check if any missing pre-requesite
         pos = target_num - 1
         for j in self.measure_df.Group:
-            if j in self.selected_df.Group:
+            if j not in self.selected_df.Group:
                 prereq_group = self.priority.index[self.priority.loc[:, j].notna()]
                 # If there are, add the one with the highest saving/cost ratio by replacing the previously selected
                 # measure with the lowest ratio
                 if len(prereq_group) > 0 and not self.selected_df.Group.isin(prereq_group).any():
                     missing_inds = self.measure_df.Group.isin(prereq_group)
                     # TODO: expanded data handled the same as above
-                    ratio_missing = self.measure_df[lookup['data'] + ' ' + str(self.timeline[0])][missing_inds]
+                    ratio_missing = self.measure_df[col_label_by_year(LOOKUP[scenario]['data'],self.timeline[0])][missing_inds]
                     ratio_missing = ratio_missing * self.measure_df.Life[missing_inds]
                     ratio_missing = (ratio_missing / self.measure_df.Cost[missing_inds]).sort_values(ascending=False).dropna()
                     if self.selected_df.Group[ratio.index[pos]] == j:
@@ -192,7 +192,6 @@ class Optimizer:
 
         self.Xmat = self.Xmat[ind_priority]
         self.ns = self.Xmat.shape[0]
-
         # State matrix converted to indicator
         self.Xmat_ind = np.zeros([self.ns, np.sum(self.Msub)], dtype=bool)
         marks = np.insert(np.array(np.cumsum(self.Msub)), 0, 0)[:-1]
@@ -201,15 +200,13 @@ class Optimizer:
         Xmat_re = np.array(list(itertools.product(*[[0] + x for x in df_tmp.groupby("Group").Index_re.apply(list)])))
         for i, Xvec in enumerate(Xmat_re[ind_priority]):
             self.Xmat_ind[i, marks[Xvec > 0] + Xvec[Xvec > 0] - 1] = 1
-
         # Pre-computation
-        lookup = self.lookups[scenario]
         reductions_by_t = []
         for t, _ in enumerate(self.timeline):
-            reduction_at_t = self.Xmat_ind @ self.selected_df[lookup['data'] + ' ' + str(self.timeline[t])]
+            reduction_at_t = self.Xmat_ind @ self.selected_df[col_label_by_year(LOOKUP[scenario]['data'],self.timeline[t])]
             reductions_by_t.append(reduction_at_t)
 
-        setattr(self, lookup['reduction'], reductions_by_t)
+        setattr(self, LOOKUP[scenario]['reduction'], reductions_by_t)
         self.annual_bill_saving = self.Xmat_ind @ self.selected_df.Annual_Saving
 
     def _optimize(self, scenario='Consumption', target_only=False):
@@ -219,7 +216,6 @@ class Optimizer:
         care about the cost and saving cashflows, but only want to see if I can meet the target within budget, priority
         and start year constraints
         """
-        lookup = self.lookups[scenario]
         time_diff: np.ndarray = np.diff(self.timeline)
         delta_n: np.ndarray[np.float64] = (self.delta ** self.selected_df.Life).to_numpy()
         all_indices: np.ndarray[np.int64] = np.arange(self.ns, dtype=np.int64)
@@ -294,7 +290,6 @@ class Optimizer:
             else:
                 current_time_range = range(0)
 
-
             # Compute V_t for each state
             for i in range(self.ns):
                 # Check if the state is possible at all by start year
@@ -307,17 +302,21 @@ class Optimizer:
                 else:
                     ind_feasible = ind_feasible_list[i]
 
-                # Exclude infeasible decision variables by priority and budget
+                # Exclude infeasible decision variables by priority, budget, reduction
                 ind_feasible = ind_feasible & ind_priority[i]
-                Xnew_ind = self.Xmat_ind[ind_feasible] & ~self.Xmat_ind[i]
-                costs = Xnew_ind @ cost_values
-                ind_cost = (costs <= budget)
+                ind_feasible = self._exclude_redundant_variables(scenario, ind_feasible, t, i)
 
+                Xnew_ind = self.Xmat_ind[ind_feasible] & ~self.Xmat_ind[i]
+                cost_per_state = Xnew_ind @ cost_values
+                ind_cost = (cost_per_state <= budget)
+                
                 if not ind_cost.any():
                     continue
 
                 # Index of feasible decision variables in self.Xmat (self.Xmat_ind)
                 index_feasible = all_indices[ind_feasible][ind_cost]
+                if len(index_feasible) == 0:
+                    continue
 
                 # Compute V_t values
                 obj_vals = excess_payment[index_feasible, time_span]
@@ -327,13 +326,14 @@ class Optimizer:
                 obj_vals = obj_vals + disc * Vnext[index_feasible]
                 if not target_only:
                     costs_inc = self.Xmat_ind[index_feasible] @ (discounted_cost)  # Cost for replacement
-                    obj_vals = obj_vals + costs[ind_cost] + costs_inc - sum_disc * self.annual_bill_saving[index_feasible]
+                    obj_vals = obj_vals + cost_per_state[ind_cost] + costs_inc - sum_disc * self.annual_bill_saving[index_feasible]
 
                 idx_min = obj_vals.argmin()
                 Xt_idx[t, i] = index_feasible[idx_min]
                 V[i] = obj_vals[idx_min]
                 if t == 0:  # Note for t=0, only V(0) needs assessment
                     break
+                
             Vnext = V
 
         # Forward recursion
@@ -364,6 +364,40 @@ class Optimizer:
             ind2 = self.Xmat[:, selected_priority[j].notna()].any(axis=1)
             ind_priority[idx, ind1 & (~ind2)] = False
     
+    def _exclude_redundant_variables(self, scenario, ind_feasible, t, state_i):
+        """
+        Remove feasible states when the transition does not reduce any fuel
+        that state_i has not entirely reduced.
+
+        :param ind_feasible: decision variables known to be feasible from state_i
+        :param t: index of current period
+        :param state_i: state index from which transition may occur
+        """
+        time_diff = np.diff(self.timeline)
+        year_idx = time_diff[:(t+1)].sum()
+
+        baseline_elec = getattr(self.baseline, LOOKUP[scenario]['baseline_electricity']).values[year_idx]
+        baseline_gas = getattr(self.baseline, LOOKUP[scenario]['baseline_gas']).values[year_idx]
+
+        elec_col_label = col_label_by_year(LOOKUP[scenario]['electricity'], self.timeline[t])
+        elec_reduction = getattr(self.measure_df, elec_col_label ).to_numpy()
+        elec_reduction = np.sum(self.Xmat_ind * elec_reduction, axis=1)
+
+        gas_col_label = col_label_by_year(LOOKUP[scenario]['gas'], self.timeline[t])
+        gas_reduction = getattr(self.measure_df, gas_col_label).to_numpy()
+        gas_reduction = np.sum(self.Xmat_ind * gas_reduction, axis=1)
+
+        gas_usage = baseline_gas - gas_reduction
+        # gas_usage = np.where(gas_usage > 0, gas_usage, 0) # cannot have negative gas usage
+        elec_usage = baseline_elec - elec_reduction
+        # elec_usage = np.where(elec_usage > 0, elec_usage, 0)
+        
+        gas_delta = gas_usage - gas_usage[state_i]
+        elec_delta = elec_usage - elec_usage[state_i]
+        reduced_ind = ind_feasible if (gas_usage[state_i] > 0) else ind_feasible & (gas_delta == 0)
+        # reduced_indices = reduced_indices if (elec_usage[state_i] > 0) else (ind_feasible & (elec_delta == 0)) | reduced_indices
+        return reduced_ind
+
 
     def _compute_excess_payment(self, scenario, time):
         """
@@ -371,17 +405,16 @@ class Optimizer:
         :param int time:
         :return NDArray:
         """
-        lookup = self.lookups[scenario]
-        baseline_usage = getattr(self.baseline, lookup['optimize']).values[None, :]
-        current_reduction= getattr(self, lookup['reduction'])[time][:, None]
-        current_usage = baseline_usage - current_reduction
-        target_usage = np.array(getattr(self, lookup['target']))[None, :]
 
+        baseline_usage = getattr(self.baseline, LOOKUP[scenario]['optimize']).values[None, :]
+        current_reduction = getattr(self, LOOKUP[scenario]['reduction'])[time][:, None]
+
+        target_usage = np.array(getattr(self, LOOKUP[scenario]['target']))[None, :]
         excess = baseline_usage - current_reduction - target_usage
-        excess_payment = np.zeros([self.ns, self.total_years])
-        # breakpoint()
-        excess_payment[excess > 0] = excess[excess > 0] * self.penalty
-        # excess_payment = np.where(current_usage > 0, excess_payment, np.inf)
+        
+        # excess_payment = np.zeros([self.ns, self.total_years])
+        excess_payment = np.where(excess > 0, excess, 0)
+        excess_payment = excess_payment * self.penalty
         return excess_payment
 
 
@@ -389,26 +422,25 @@ class Optimizer:
         """
         Perform forward calculation of energy reductions given a configuration of scenario installations.
         """
-        lookup = self.lookups[scenario]
 
         data = {scenario: [], 'Electricity': [], 'Gas': [], 'Year': self.timeline}
         for t, time in enumerate(self.timeline):
             scenarios_for_t = scenario_selection[t]
             for name in ['data', 'electricity', 'gas']:
                 store_as = scenario if name == 'data' else name.capitalize()
-                data_by_t = self.measure_df[lookup[name] + ' ' + str(time)]
+                data_by_t = self.measure_df[col_label_by_year(LOOKUP[scenario][name],time)]
                 data[store_as].append((scenarios_for_t @ data_by_t.values.reshape([-1, 1])).reshape(-1)[0])
         scenario_df = pd.DataFrame(data).merge(self.timeline_df, on='Year', how='right')
         scenario_df = scenario_df.fillna(method='ffill').set_index('Year')
 
         # Collect what the new reduced emissions/consumption will be
         output_df = pd.DataFrame({
-            'levels_reduced_to': self.baseline[lookup['optimize']] - scenario_df[scenario],
-            'electricity_reduced_to': self.baseline[lookup['baseline_electricity']] - scenario_df['Electricity'],
-            'gas_reduced_to': self.baseline[lookup['baseline_gas']] - scenario_df['Gas'],
+            'levels_reduced_to': self.baseline[LOOKUP[scenario]['optimize']] - scenario_df[scenario],
+            'electricity_reduced_to': self.baseline[LOOKUP[scenario]['baseline_electricity']] - scenario_df['Electricity'],
+            'gas_reduced_to': self.baseline[LOOKUP[scenario]['baseline_gas']] - scenario_df['Gas'],
         })
 
-        setattr(self, lookup['level'], output_df)
+        setattr(self, LOOKUP[scenario]['level'], output_df)
         return {'solution': self.Xoptimal, 'objective': self.total_cost}
 
     def optimize(self,
@@ -419,21 +451,17 @@ class Optimizer:
                  scenario_selection=None,
                  scenario_costs_savings=None,
                  measure_df=None):
-        lookup = self.lookups[scenario]
 
         if max_iter is None:
             max_iter = target_num
 
-        def col_label_by_year(col, year):
-            return col + ' ' + str(year)
-
         # Expand Elec/NatGas and Total C02/Savings column of lists into separate columns
-        for column in [lookup['electricity'], lookup['gas'], 'Total_CO2', 'Total_Saving']:
+        for column in [LOOKUP[scenario]['electricity'], LOOKUP[scenario]['gas'], 'Total_CO2', 'Total_Saving']:
             expanded_cols = [col_label_by_year(column,time) for time in self.timeline]
             self.measure_df[expanded_cols] = pd.DataFrame(self.measure_df[column].tolist(), index=self.measure_df.index)
 
         # Compute base scenario (install measures with maximal reducing power subject to budget constraint) at year 0
-        first_year_data = col_label_by_year(lookup['data'], self.timeline[0])
+        first_year_data = col_label_by_year(LOOKUP[scenario]['data'], self.timeline[0])
         top_measures_by_group = self.measure_df.groupby('Group', group_keys=False)[first_year_data]
         df_base = self.measure_df.loc[top_measures_by_group.idxmax().values]
         df_base = df_base.sort_values(by=first_year_data)
@@ -448,8 +476,8 @@ class Optimizer:
         delta_n = self.delta ** self.selected_df.Life
 
 
-        baseline_optimize = getattr(self.baseline, lookup['optimize'])
-        baseline_target = getattr(self, lookup['target'])
+        baseline_optimize = getattr(self.baseline, LOOKUP[scenario]['optimize'])
+        baseline_target = getattr(self, LOOKUP[scenario]['target'])
         for t in range(self.T):
             y_past = time_diff[:t].sum() if t > 0 else 0
             cost = 0
@@ -481,7 +509,7 @@ class Optimizer:
                 Xbase[[s >= t for s in range(self.T)], group_idx] = df_base.Index[i]
 
                 # Compute total cost (objective value)
-                reducing_power += getattr(df_base, col_label_by_year(lookup['data'], self.timeline[t]))[i]
+                reducing_power += getattr(df_base, col_label_by_year(LOOKUP[scenario]['data'], self.timeline[t]))[i]
                 time_delta = self.timeline[t] - self.timeline[0]
                 excess_penalty = baseline_optimize.iloc[time_delta] - reducing_power - baseline_target.iloc[time_delta]
                 excess_penalty = np.maximum(excess_penalty, 0)
@@ -525,6 +553,7 @@ class Optimizer:
                      'New Measure': self.selected_df.Identifier[self.Xoptimal_ind[t] & ~self.Xoptimal_ind[t - 1]].tolist()}
                     for t in range(1, self.T)
                 ]
+
             self.solution = pd.DataFrame(sol)
             # If the suggested solution is no inferior to the base case, return as solution found
             # If a preconfigured scenario selection is provided, always return recalculated solution
@@ -542,7 +571,7 @@ class Optimizer:
 
             measure_ids = [ID in measure_unchosen for ID in self.selected_df.Identifier]
             # TODO: with Total_CO2 being expanded, how to select? Using initial year as temp solution
-            data = lookup['data'] + ' ' + str(self.timeline[0])
+            data = col_label_by_year(LOOKUP[scenario]['data'], self.timeline[0])
             measure_to_reduce = self.selected_df.iloc[self.selected_df.loc[measure_ids][data].idxmin()]
             measure_to_reduce = measure_to_reduce.Identifier
 
@@ -551,7 +580,7 @@ class Optimizer:
             if measure_unselected:
                 measure_ids = [ID in measure_unselected for ID in self.measure_df.Identifier]
                 # TODO: with Total_CO2 being expanded, how to select? Using initial year as temp solution
-                data = lookup['data'] + ' ' + str(self.timeline[0])
+                data = LOOKUP[scenario]['data'] + ' ' + str(self.timeline[0])
                 measure_to_add = self.measure_df.iloc[self.measure_df.loc[measure_ids][data].idxmax()].Identifier
                 self.selected_df = self.selected_df[self.selected_df.Identifier != measure_to_reduce]
 
@@ -592,7 +621,7 @@ class Optimizer:
             Xoptimal_ind_for_t = self.Xoptimal_ind[t]
             for name in ['data', 'electricity', 'gas']:
                 store_as = scenario if name == 'data' else name.capitalize()
-                data_by_t = self.measure_df[lookup[name] + ' ' + str(time)]
+                data_by_t = self.measure_df[LOOKUP[scenario][name] + ' ' + str(time)]
                 data[store_as].append((Xoptimal_ind_for_t @ data_by_t.values.reshape([-1, 1])).reshape(-1)[0])
 
         scenario_df = pd.DataFrame(data).merge(self.timeline_df, on='Year', how='right')
@@ -600,11 +629,11 @@ class Optimizer:
 
         # Collect what the new reduced emissions/consumption will be
         output_df = pd.DataFrame({
-            'levels_reduced_to': self.baseline[lookup['optimize']] - scenario_df[scenario],
-            'electricity_reduced_to': self.baseline[lookup['baseline_electricity']] - scenario_df['Electricity'],
-            'gas_reduced_to': self.baseline[lookup['baseline_gas']] - scenario_df['Gas'],
+            'levels_reduced_to': self.baseline[LOOKUP[scenario]['optimize']] - scenario_df[scenario],
+            'electricity_reduced_to': self.baseline[LOOKUP[scenario]['baseline_electricity']] - scenario_df['Electricity'],
+            'gas_reduced_to': self.baseline[LOOKUP[scenario]['baseline_gas']] - scenario_df['Gas'],
         })
-        setattr(self, lookup['level'], output_df)
+        setattr(self, LOOKUP[scenario]['level'], output_df)
 
         return {'status': 'success', 'message': 'Max iteration number reached, returning base case solution'}
 
@@ -620,7 +649,6 @@ class Optimizer:
         # Retrieve new Consumption/Emission level based on baseline
         # Retrieve the associated reduction from the measures data by Electricity and Natural Gas
         # Retrieve the cost of implementing the measures at each interval
-        lookup = self.lookups[scenario]
         solution_df = self.get_solution()
         measures = solution_df['New Measure'].to_list()
 
@@ -634,8 +662,8 @@ class Optimizer:
         for year_index, set_of_measures in enumerate(measures):
             set_of_measures_df = self.measure_df[self.measure_df['Identifier'].isin(set_of_measures)]
 
-            elec_col = lookup['electricity'] + ' ' + str(self.timeline[year_index])
-            gas_col = lookup['gas'] + ' ' + str(self.timeline[year_index])
+            elec_col = col_label_by_year(LOOKUP[scenario]['electricity'],self.timeline[year_index])
+            gas_col = col_label_by_year(LOOKUP[scenario]['gas'], self.timeline[year_index])
 
             data['electricity_cycle_reduction'][year_index] = set_of_measures_df[elec_col].sum()
             data['gas_cycle_reduction'][year_index] = set_of_measures_df[gas_col].sum()
@@ -647,13 +675,13 @@ class Optimizer:
             total_gas += set_of_measures_df[gas_col].sum()
 
         output_df = pd.DataFrame(data).merge(self.timeline_df, on='Year', how='right').fillna(method='ffill')
-        output_df = output_df.set_index('Year').merge(getattr(self, lookup['level']), left_index=True, right_index=True)
+        output_df = output_df.set_index('Year').merge(getattr(self, LOOKUP[scenario]['level']), left_index=True, right_index=True)
         output_df['levels_reduced_by'] = output_df['electricity_reduced_by'] + output_df['gas_reduced_by']
         return output_df
 
 
 # ================================== Auxillary functions ===========================
-def pick_cost_efficiency(group_df, timeline, lookup):
+def pick_cost_efficiency(group_df, timeline, scenario):
     """
     Auxillary function for Optimizer._preselect. Discard measures with higher costs but strictly inferior
     energy saving/emission
@@ -668,7 +696,7 @@ def pick_cost_efficiency(group_df, timeline, lookup):
 
     # TODO: with Total_CO2 being expanded, how to select? Using initial year as temp solution
     year = ' ' + str(timeline[0])
-    col = tmp[lookup['electricity'] + year] + tmp[lookup['gas'] + year]
+    col = tmp[LOOKUP[scenario]['electricity'] + year] + tmp[LOOKUP[scenario]['gas'] + year]
     col *= tmp['Life']
 
     for i in range(1, tmp.shape[0]):
@@ -677,3 +705,6 @@ def pick_cost_efficiency(group_df, timeline, lookup):
             index = index + 1
 
     return group_df.loc[record[:index]]
+
+def col_label_by_year(col, year):
+            return col + ' ' + str(year)

--- a/beam_opt/tests.py
+++ b/beam_opt/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/beam_opt/utils/parse.py
+++ b/beam_opt/utils/parse.py
@@ -375,11 +375,13 @@ def parse_beam_measures(property_view_id: int, emission_rates: dict, timeline: l
     df = pd.DataFrame(measures, columns=MEASURE_DF_COLUMNS)
 
     # Discard expensive measures with the same effect
-    df = df.loc[df.fillna(np.inf).groupby(['Building', 'Annual_Saving']).Cost.idxmin().fillna(0).astype(int)]
+    df = df.loc[df.fillna(np.inf).groupby(['Building', 'Annual_Saving', 'Category']).Cost
+                .idxmin().fillna(0).astype(int)]
     df.sort_index(inplace=True)
 
     # Discard less effective measures with the same cost
-    df = df.loc[df.fillna(np.inf).groupby(['Building', 'Cost']).Annual_Saving.idxmax().fillna(0).astype(int)]
+    df = df.loc[df.fillna(np.inf).groupby(['Building', 'Cost', 'Category']).Annual_Saving
+                .idxmax().fillna(0).astype(int)]
     df.sort_index(inplace=True)
 
     # ###  Build dataframe with base information about the property

--- a/beam_opt/utils/utils.py
+++ b/beam_opt/utils/utils.py
@@ -1,0 +1,26 @@
+def dump_optimizer_input(parsed_input, path=None):
+    """
+    Write or return a JSON string of CompleteData input
+    """
+    import json
+    result = json.dumps(parsed_input)
+    if path is None:
+        return result
+    with open(path, 'w') as f:
+        f.write(result)
+
+
+def dump_optimizer_result(scenarios, levels, path=None):
+    """
+    Write or return a JSON string of the serialized result
+    """
+    result = {}
+    result['MEASURES'] = scenarios
+    result['LEVELS'] = levels
+    import json
+    result = json.dumps(result)
+    if path is None:
+        return result
+
+    with open(path, 'w') as f:
+        f.write(result)

--- a/beam_opt/utils/validate.py
+++ b/beam_opt/utils/validate.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from beam_opt.models.data_container import CompleteData
-from beam_opt.models.optimizer import Optimizer
+from beam_opt.models.optimizer import Optimizer, LOOKUP
 
 BASELINE_VALIDATION_COLUMNS = ['Annual_Bill', 'Electricity_CO2', 'Gas_CO2', 'Total_CO2', 'Electricity_Consumption',
                                'Gas_Consumption', 'Electricity_Bill', 'Gas_Bill']
@@ -112,8 +112,8 @@ def pre_validate_parameters(optimizer: Optimizer, budget, target, penalty, delta
     target_df = pd.DataFrame({'Target': target, 'Year': optimizer.timeline}
                              ).merge(timeline_df, on='Year', how='right').fillna(method='ffill').set_index('Year')
 
-    if scenario in optimizer.lookups:
-        lookup = optimizer.lookups[scenario]
+    if scenario in LOOKUP:
+        lookup = LOOKUP[scenario]
         if np.isinf(penalty):
             # Check whether target is achievable
             target = target_df.Target * optimizer.baseline[lookup['optimize']].iloc[0]
@@ -135,7 +135,7 @@ def post_validate_parameters(optimizer: Optimizer, scenario):
     """
     Check that consumption/emission targets were set sucessfully
     """
-    lookup = optimizer.lookups[scenario]
+    lookup = LOOKUP[scenario]
     errors = []
     if not hasattr(optimizer, lookup['target']):
         errors.append('Must set Target before calling Optimization')


### PR DESCRIPTION
#### Problem
This supplies the current solution to handle negative gas emissions. The current problem is approximately the following:

- The optimizer picks measures on year t that reduce emissions due to gas below zero.
- On year t' after t, there is some penalty on emissions due to over usage of electricity (contributing a penalty). There is some set of measures that can be chosen to reduce emissions, but only emissions due to gas.
- The optimizer will select this measure since it only looks at the cumulative emissions that a measure reduces. There is no reason to select the other available measure since natural gas is completely reduced.

#### Solution

When selecting feasible states to transition to from a given state, we check if gas can still be reduced. If yes, then any feasible state transition is allowed. Otherwise, the state transition is only allowed if there is no further decrease in gas.

```
# see exclude_redundant_variables
reduced_ind = ind_feasible if (gas_usage[state_i] > 0) else ind_feasible & (gas_delta == 0)
```

#### Future concerns
- This solution does not account for reductions due to electricity
- This solution does not account for a state transition that reduces both electricity and gas from a state where gas is less that or equal to zero, electricity > 0, and the transition is beneficial. (e.g. measure reduces gas by 1 and electricity by 10^5, or any similar, beneficial extreme)
- Need to update/bypass the calculation of the base case since it does not account for the negative gas problem. Current "solution" is to accept the first solution.