### PR TITLE
Baseline emission rates and multiple penalties

### DIFF
--- a/beam_opt/models/data_container.py
+++ b/beam_opt/models/data_container.py
@@ -13,8 +13,8 @@ from beam_opt.utils.parse import group_identifier_rmi
 
 class CompleteData:
     """
-    Take dataframe (measure_data) returned by parse function as input, add exclusion/priority relationship for use
-    of optimization program
+    Take dataframe (measure_data) returned by parse function as input,
+    and add exclusion/priority relationship for use of optimization program
     """
 
     def __init__(self, parsed_data, file_exclusion, default_priority=None, source='RMI'):
@@ -38,6 +38,7 @@ class CompleteData:
             # Format Measures into Groups based on their Group name
             self.measure_data = parsed_data['measure_data'].groupby('Building', group_keys=False).apply(
                 lambda x: add_group_buildingsync(x))
+
         self.measure_data['Building'] = self.measure_data['Building'].astype(str)
 
         # Parse priority for all exclusion groups

--- a/beam_opt/utils/parse.py
+++ b/beam_opt/utils/parse.py
@@ -384,17 +384,16 @@ def parse_beam_measures(property_view_id: int, emission_rates: dict, timeline: l
                 .idxmax().fillna(0).astype(int)]
     df.sort_index(inplace=True)
 
+    # missing_columns = []
+    # for column in PROPERTY_STATE_REQUIRED_COLUMNS:
+    #     if column not in state.extra_data:
+    #         missing_columns.append(column)
 
-    missing_columns = []
-    for column in PROPERTY_STATE_REQUIRED_COLUMNS:
-        if column not in state.extra_data:
-            missing_columns.append(column)
-    
-    if missing_columns:
-        return {
-            'status': 'error',
-            'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)
-        }
+    # if missing_columns:
+    #     return {
+    #         'status': 'error',
+    #         'message': 'The property is missing the following columns, please add %s' % ', '.join(missing_columns)
+    #     }
 
     baseline_elec = state.extra_data.get('Electricity Use - Grid Purchase (kBtu)')
     baseline_gas = state.extra_data.get('Natural Gas Use (kBtu)')
@@ -597,6 +596,7 @@ def _worse_scenario(left_scenario, right_scenario):
 
     return left_scenario if left_savings <= right_savings else right_scenario
 
+
 def _baseline_fuels_by_emission_rates(emission_rates, timeline, baseline_elec, baseline_gas):
     """
     """
@@ -616,4 +616,3 @@ def _baseline_fuels_by_emission_rates(emission_rates, timeline, baseline_elec, b
         years_past += period_len
 
     return elec_use, gas_use
-

--- a/beam_opt/utils/validate.py
+++ b/beam_opt/utils/validate.py
@@ -88,7 +88,13 @@ def validate_complete_data(complete_data: CompleteData, ids):
     return errors if errors else None
 
 
-def pre_validate_parameters(optimizer: Optimizer, budget, target, penalty, delta):
+def pre_validate_parameters(
+        optimizer: Optimizer,
+        budget, target,
+        penalty_emission,
+        penalty_consumption,
+        penalty_flat,
+        delta):
     """
     Check that all of the parameters are valid
     """
@@ -104,7 +110,9 @@ def pre_validate_parameters(optimizer: Optimizer, budget, target, penalty, delta
         errors.append('Invalid input: must choose target > 0')
     if delta < 0 or delta > 1:  # discount factor
         errors.append('Invalid input: must choose delta in [0,1]')
-    if penalty < 0:  # penalty rate for consumption/emission
+    if penalty_emission < 0 \
+            or penalty_consumption < 0 \
+            or penalty_flat < 0:
         errors.append('Invalid input: must choose nonnegative penalty')
 
     # Check that Target is Achievable
@@ -114,7 +122,9 @@ def pre_validate_parameters(optimizer: Optimizer, budget, target, penalty, delta
 
     if optimizer.scenario in LOOKUP:
         lookup = LOOKUP[optimizer.scenario]
-        if np.isinf(penalty):
+        if np.isinf(penalty_emission) \
+                or np.isinf(penalty_consumption) \
+                or np.isinf(penalty_flat):
             # Check whether target is achievable
             target = target_df.Target * optimizer.baseline[lookup['optimize']].iloc[0]
             max_reduction = optimizer.df.groupby('Group')[lookup['data']].max().sum()
@@ -140,4 +150,3 @@ def post_validate_parameters(optimizer: Optimizer):
     if not hasattr(optimizer, lookup['target']):
         errors.append('Must set Target before calling Optimization')
     return errors if errors else None
-


### PR DESCRIPTION
#### What's this PR do?
###### Baseline by emission factor:
Updates the construction phase of the optimizer to take in a baseline usage dataframe that gives an array of usage for each fuel type across all years in the timeline.

###### Penalty calculation:
Allows a composition of penalties to be applied during a measures optimization. The logic for applying a penalty to a scalar or n-dimensional array is now handled by `Optimizer._apply_penalty()`.

###### Penalty result:
The optimizer will return the penalty result WITHOUT application of the discount rate (intended behavior). However, the optimizer WILL account for discount rate in the backward recursion phase.

NOTE: We may need to look more closely at the calculation of the discount rate in the backward recursion phase. The discount seems to be applied only from the start year of a cycle. Example: the last cycle has a single year and will not be discounted at all. This can be easily noticed when running an optimization with only a flat rate penalty.